### PR TITLE
Python 3 and Django 1.8 support.

### DIFF
--- a/admin_views/admin.py
+++ b/admin_views/admin.py
@@ -39,8 +39,13 @@ class AdminViews(admin.ModelAdmin):
                 )
                 self.local_view_names.append(link[0])
 
+                try:
+                    model_name = self.model._meta.model_name
+                except AttributeError:
+                    model_name = self.model._meta.module_name  # removed as of Django 1.8
+
                 # Build URL from known info
-                info = self.model._meta.app_label, self.model._meta.module_name
+                info = self.model._meta.app_label, model_name
                 self.output_urls.append((
                         'view',
                         link[0],

--- a/admin_views/management/commands/admin_views_install_templates.py
+++ b/admin_views/management/commands/admin_views_install_templates.py
@@ -23,29 +23,29 @@ class Command(BaseCommand):
             dest_dir = os.path.join(template_dirs[0], 'admin/')
         else:
             # Give user the option of picking which directory from their list
-            print "Which directory would you like the templates installed in?"
-            print "NOTE: The first is *usually* the correct answer."
-            print
+            print("Which directory would you like the templates installed in?")
+            print("NOTE: The first is *usually* the correct answer.")
+            print()
 
             for i, dir in enumerate(template_dirs, start=1):
-                print "    %d) %s" % (i, dir)
+                print("    %d) %s" % (i, dir))
 
-            print
+            print()
 
-            input = raw_input('Enter directory number: ')
+            input_ = input('Enter directory number: ')
             try:
-                dir_num = int(input)
+                dir_num = int(input_)
             except ValueError:
-                print "ERROR: %r is not a number, please try again." % input
+                print("ERROR: %r is not a number, please try again." % input_)
                 return
 
             dest_dir = os.path.join(template_dirs[dir_num-1], 'admin/')
 
-        print "Copying templates to '%s'" % dest_dir
+        print("Copying templates to '%s'" % dest_dir)
 
         # Create the admin directory if necessary
         if not os.path.exists(dest_dir):
-            print "Creating intermediate directories..."
+            print("Creating intermediate directories...")
             os.makedirs(dest_dir)
 
         copyfile(
@@ -53,4 +53,4 @@ class Command(BaseCommand):
                 os.path.join(dest_dir, "index.html")
             )
 
-        print "Done."
+        print("Done.")

--- a/admin_views/management/commands/admin_views_install_templates.py
+++ b/admin_views/management/commands/admin_views_install_templates.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 from shutil import copyfile
 
@@ -31,6 +32,11 @@ class Command(BaseCommand):
                 print("    %d) %s" % (i, dir))
 
             print()
+
+            try:
+               input = raw_input
+            except NameError:
+               pass
 
             input_ = input('Enter directory number: ')
             try:

--- a/admin_views/templatetags/admin_views.py
+++ b/admin_views/templatetags/admin_views.py
@@ -1,3 +1,5 @@
+import sys
+
 from django import template
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -6,6 +8,15 @@ from django.contrib.admin import site
 from ..admin import AdminViews
 
 register = template.Library()
+
+if sys.version_info < (3,):
+    import codecs
+    def u(x):
+        return codecs.unicode_escape_decode(x)[0]
+else:
+    def u(x):
+        return x
+
 
 @register.simple_tag
 def get_admin_views(app_name, perms):
@@ -28,14 +39,14 @@ def get_admin_views(app_name, perms):
                     alt_text = "Custom admin view '%s'" % name
 
                 output.append(
-                        """<tr>
+                        u("""<tr>
                               <th scope="row">
                                   <img src="%s" alt="%s" />
                                   <a href="%s">%s</a></th>
                               <td>&nbsp;</td>
                               <td>&nbsp;</td>
                            </tr>
-                        """ % (img_url, alt_text, link, name)
+                        """) % (img_url, alt_text, link, name)
                     )
 
     return "".join(output)

--- a/admin_views/templatetags/admin_views.py
+++ b/admin_views/templatetags/admin_views.py
@@ -28,7 +28,7 @@ def get_admin_views(app_name, perms):
                     alt_text = "Custom admin view '%s'" % name
 
                 output.append(
-                        u"""<tr>
+                        """<tr>
                               <th scope="row">
                                   <img src="%s" alt="%s" />
                                   <a href="%s">%s</a></th>


### PR DESCRIPTION
Added support for Python 3 and Django 1.8.

closes #6.

Also it seems to me that there is no need in admin_views_install_templates command.
At least in 1.8 you shouldn't run this script. All you have to do is just to place the 'admin_views' app before the 'django.contrib.admin' in INSTALLED_APPS.