### PR TITLE
check app_label instead of verbose name

### DIFF
--- a/admin_views/templates/admin/index.html
+++ b/admin_views/templates/admin/index.html
@@ -38,7 +38,7 @@
             {% endif %}
             </tr>
         {% endfor %}
-        {% get_admin_views app.name perms %}
+        {% get_admin_views app perms %}
         </table>
         </div>
     {% endfor %}

--- a/admin_views/templatetags/admin_views.py
+++ b/admin_views/templatetags/admin_views.py
@@ -19,12 +19,12 @@ else:
 
 
 @register.simple_tag
-def get_admin_views(app_name, perms):
+def get_admin_views(app, perms):
     output = []
     STATIC_URL = settings.STATIC_URL
 
     for k, v in site._registry.items():
-        if app_name.lower() not in str(k._meta):
+        if app['app_label'] not in str(k._meta):
             continue
 
         if isinstance(v, AdminViews):


### PR DESCRIPTION
resolve an issue where apps have a different name set in their `AppConfig`