### PR TITLE
Allow use of custom admin site

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ Installation Steps
    You will be prompted for which of these directories you would like it installed
    in if there are multiple directories defined.
 
+If you are using a custom Admin Site, you'll need to configure the ``ADMIN_VIEWS_SITE`` setting to point to your admiin site instance::
+
+    ADMIN_VIEWS_SITE = 'myproject.admin.admin_site'
+
 Usage
 =====
 

--- a/admin_views/compat.py
+++ b/admin_views/compat.py
@@ -1,0 +1,4 @@
+try:
+    from django.utils.module_loading import import_string
+except ImportError:
+    from django.utils.module_loading import import_by_path as import_string

--- a/admin_views/conf.py
+++ b/admin_views/conf.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+
+ADMIN_VIEWS_SITE = getattr(settings, 'ADMIN_VIEWS_SITE', 'django.contrib.admin.site')

--- a/admin_views/templatetags/admin_views.py
+++ b/admin_views/templatetags/admin_views.py
@@ -1,13 +1,15 @@
 import sys
-
 from django import template
 from django.conf import settings
-from django.core.urlresolvers import reverse
-from django.contrib.admin import site
 
+from .. import conf
 from ..admin import AdminViews
+from ..compat import import_string
+
+site = import_string(conf.ADMIN_VIEWS_SITE)
 
 register = template.Library()
+
 
 if sys.version_info < (3,):
     import codecs


### PR DESCRIPTION
`django-admin-views` assumes the user is using the default admin site, and only iterates through the app that are included there by default (`auth` and `sites`)